### PR TITLE
Add OpenCV4 support in camera model

### DIFF
--- a/camera_model/src/calib/CameraCalibration.cc
+++ b/camera_model/src/calib/CameraCalibration.cc
@@ -232,7 +232,12 @@ CameraCalibration::drawResults(std::vector<cv::Mat>& images) const
         cv::Mat& image = images.at(i);
         if (image.channels() == 1)
         {
-            cv::cvtColor(image, image, CV_GRAY2RGB);
+            #if (CV_VERSION_MAJOR >= 4)
+                cv::cvtColor(image, image, cv::COLOR_GRAY2RGB);
+            #else
+                cv::cvtColor(image, image, CV_GRAY2RGB);
+            #endif
+            
         }
 
         std::vector<cv::Point2f> estImagePoints;
@@ -242,20 +247,28 @@ CameraCalibration::drawResults(std::vector<cv::Mat>& images) const
         float errorSum = 0.0f;
         float errorMax = std::numeric_limits<float>::min();
 
+        int flag_antialiasing;
+        #if (CV_VERSION_MAJOR >= 4)
+            flag_antialiasing = cv::LINE_AA;
+        #else
+            flag_antialiasing = CV_AA;
+        #endif
+
         for (size_t j = 0; j < m_imagePoints.at(i).size(); ++j)
         {
             cv::Point2f pObs = m_imagePoints.at(i).at(j);
             cv::Point2f pEst = estImagePoints.at(j);
 
+
             cv::circle(image,
                        cv::Point(cvRound(pObs.x * drawMultiplier),
                                  cvRound(pObs.y * drawMultiplier)),
-                       5, green, 2, CV_AA, drawShiftBits);
+                       5, green, 2, flag_antialiasing, drawShiftBits);
 
             cv::circle(image,
                        cv::Point(cvRound(pEst.x * drawMultiplier),
                                  cvRound(pEst.y * drawMultiplier)),
-                       5, red, 2, CV_AA, drawShiftBits);
+                       5, red, 2, flag_antialiasing, drawShiftBits);
 
             float error = cv::norm(pObs - pEst);
 
@@ -272,7 +285,7 @@ CameraCalibration::drawResults(std::vector<cv::Mat>& images) const
 
         cv::putText(image, oss.str(), cv::Point(10, image.rows - 10),
                     cv::FONT_HERSHEY_COMPLEX, 0.5, cv::Scalar(255, 255, 255),
-                    1, CV_AA);
+                    1, flag_antialiasing);
     }
 }
 

--- a/camera_model/src/intrinsic_calib.cc
+++ b/camera_model/src/intrinsic_calib.cc
@@ -233,11 +233,18 @@ int main(int argc, char** argv)
         // visualize observed and reprojected points
         calibration.drawResults(cbImages);
 
+        int flag_antialiasing;
+        #if (CV_VERSION_MAJOR >= 4)
+            flag_antialiasing = cv::LINE_AA;
+        #else
+            flag_antialiasing = CV_AA;
+        #endif
+
         for (size_t i = 0; i < cbImages.size(); ++i)
         {
             cv::putText(cbImages.at(i), cbImageFilenames.at(i), cv::Point(10,20),
                         cv::FONT_HERSHEY_COMPLEX, 0.5, cv::Scalar(255, 255, 255),
-                        1, CV_AA);
+                        1, flag_antialiasing);
             cv::imshow("Image", cbImages.at(i));
             cv::waitKey(0);
         }


### PR DESCRIPTION
This PullRequest adds OpenCV4 support to GVINS. The modified code is the camera model implementation and consists of new type definitions (they changed from older OpenCV versions). Older OpenCV versions are still supported by adding a preprocessor directive which only replaces the code when the version flag is set accordingly.

I hope this will contribute to making GVINS even more awesome than it currently is.